### PR TITLE
push to Maven Central

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,10 +19,8 @@ jobs:
       - checkout
       - run:
           name: build
-          command: |
-            set -euo pipefail
+          command: ./build.sh
 
-            sbt test
   release:
     docker:
     - image: cimg/openjdk:11.0.13
@@ -34,8 +32,18 @@ jobs:
           name: release
           command: |
             set -euo pipefail
+            export PGP_PASSPHRASE=""
+            export PGP_SECRET="$gpg_code_signing"
+            export SONATYPE_PASSWORD="$MAVEN_PASSWORD"
+            export SONATYPE_USERNAME="$MAVEN_USERNAME"
+            export CI_COMMIT_TAG=1
 
-            echo "TODO: release"
+            deploy=$(git log -n1 --format="%(trailers:key=deploy,valueonly)" $COMMIT)
+            if [ "$deploy" = "true" ]; then
+              while IFS='' read -r p || [ -n "$p" ]; do
+                ./release.sh $p
+              done < release.txt
+            fi
 
 workflows:
   version: 2
@@ -45,6 +53,9 @@ workflows:
     - release:
         requires:
         - build
+        context:
+        # Despite the name, that's where the Sonatype credentials are.
+        - npn-publish
         filters:
           branches:
             only: main

--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,5 @@ metals.sbt
 
 # Mac
 .DS_Store
+
+.envrc.private

--- a/README.md
+++ b/README.md
@@ -1,7 +1,11 @@
 # Application Runtime
 
 This repository is meant to contain all of the open-source projects under the
-remit of the Application Runtime team. For now, most of them are under the
-[daml] repository. They will be moved here over time.
+remit of the Application Runtime team (for now).
+
+Currently most of them are under the [daml] repository. They will be moved here
+over time. We may revisit how these things are organized later down the line;
+the main purpose of moving things from [daml] to here is to break projects off
+from the Bazel monobuild.
 
 [daml]: https://github.com/digital-asset/daml

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+dir="$( cd -- "${BASH_SOURCE[0]%/*}" &> /dev/null && pwd )"
+cd $dir
+
+for project in scalatest-utils; do (
+    cd $project
+    sbt test
+) done

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,0 @@
-sbt.version=1.6.2

--- a/release.sh
+++ b/release.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+dir="$( cd -- "${BASH_SOURCE[0]%/*}" &> /dev/null && pwd )"
+cd $dir
+
+PROJECT=$1
+VERSION=$2
+
+if [ "$CI" != "true" ]; then
+    echo "This script is meant to be run on CI only."
+fi
+
+cd $PROJECT
+sbt ci-release

--- a/release.txt
+++ b/release.txt
@@ -1,0 +1,1 @@
+scalatest-utils 2.2.0

--- a/scalatest-utils/build.sbt
+++ b/scalatest-utils/build.sbt
@@ -2,13 +2,28 @@
 // SPDX-License-Identifier: Apache-2.0
 
 ThisBuild / scalaVersion := "2.13.8"
-ThisBuild / version := sys.env.get("VERSION").getOrElse("local")
 ThisBuild / organization := "com.daml"
 ThisBuild / organizationName := "Digital Asset"
 ThisBuild / licenses := Seq("Apache-2.0" -> url("http://www.apache.org/licenses/LICENSE-2.0.html"))
+ThisBuild / homepage := Some(url("https://docs.daml.com"))
 
+// Setting version to bypass sbt-dynver (and control version string format)
+ThisBuild / version := sys.env.get("VERSION").getOrElse("local")
 
-lazy val scalatest_utils = (project in file("scalatest-utils"))
+sonatypeCredentialHost := "s01.oss.sonatype.org"
+sonatypeRepository := "https://s01.oss.sonatype.org/service/local"
+// Note: the built-in `developers` list does not contain the same information
+// we published from the daml repo; manually setting for consistency
+pomExtra := <developers>
+    <developer>
+      <name>Digital Asset SDK Feedback</name>
+      <email>sdk-feedback@digitalasset.com</email>
+      <organization>Digital Asset (Switzerland) GmbH</organization>
+      <organizationUrl>https://www.digitalasset.com/developers</organizationUrl>
+    </developer>
+  </developers>
+
+lazy val root = (project in file("."))
   .settings(
     name := "scalatest-utils",
     libraryDependencies ++= Seq(

--- a/scalatest-utils/project/plugins.sbt
+++ b/scalatest-utils/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("com.github.sbt" % "sbt-ci-release" % "1.5.10")


### PR DESCRIPTION
This PR sets up a release pipeline where individual SBT projects can be pushed to Maven Central by crafting a special commit with a `deploy: true` trailer. The process will deploy all of the listed projects in `release.txt` along with their versions.

It is the release manager's responsibility to make sure `release.txt` only contains new, unreleased project/version entries. The format of a line in the `release.txt` file is `<project name> <version>`.